### PR TITLE
Conditionally add possibly missing columns

### DIFF
--- a/R/make_gr_part_E.R
+++ b/R/make_gr_part_E.R
@@ -30,10 +30,17 @@ make_gr_part_E <- function(df, ugender) {
                                GENDERDETAIL == 3 ~ "GRGU011",
                                GENDERDETAIL == 4 ~ "GRGU012")) %>%
     select(-.data$GENDERDETAIL) %>%
-    pivot_wider(names_from = .data$GEN_COL, values_from = .data$COUNT) %>%
-    #add missing columns as nulls, if they don't already exist in the data
-    dplyr::union_all(data.frame(GRGU011 = integer(),
-                                GRGU012 = integer())) %>%
+    pivot_wider(names_from = .data$GEN_COL, values_from = .data$COUNT)
+
+  #add missing columns as nulls, if they don't already exist in the data
+  if (!"GRGU011" %in% names(partE)) {
+    partE[["GRGU011"]] <- NA_integer_
+  }
+  if (!"GRGU012" %in% names(partE)) {
+    partE[["GRGU012"]] <- NA_integer_
+  }
+
+  partE <- partE %>%
             #if ugender is true, we can report on another gender
     mutate(GRGU01 = case_when(ugender == TRUE ~ 1,
                               TRUE ~ 2),


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`union_all()` now requires that `x` and `y` are compatible data frames with the same columns. This is consistent with the other set operation helpers that dplyr provides. In this package, `union_all()` was being called on a data frame with 5 columns and one with 2 columns, which is no longer allowed. I think I've reworked this into a more expressive way to do what you were trying to accomplish, but you should definitely take a look.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!